### PR TITLE
fix(docs): Add react-helmet as peerDep

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Performant asynchronous font loading & Flash Of Unstyled Text (FOUT) handling pl
 
 ## Install
 
-`npm install --save-dev gatsby-omni-font-loader`
+`npm install --save-dev gatsby-omni-font-loader react-helmet`
 
 or
 
-`yarn add --dev gatsby-omni-font-loader`
+`yarn add --dev gatsby-omni-font-loader react-helmet`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Performant asynchronous font loading & Flash Of Unstyled Text (FOUT) handling pl
 
 ## Install
 
-`npm install --save-dev gatsby-omni-font-loader react-helmet`
+`npm install gatsby-omni-font-loader react-helmet`
 
 or
 
-`yarn add --dev gatsby-omni-font-loader react-helmet`
+`yarn add gatsby-omni-font-loader react-helmet`
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/codeAdrian/gatsby-omni-font-loader"
   },
   "peerDependencies": {
-    "gatsby": ">=1"
+    "gatsby": ">=1",
+    "react-helmet": "^6.1.0"
   }
 }


### PR DESCRIPTION
Hi! Thanks for the plugin, it's working great!

Since I tried it out on a barebones project, I didn't have `react-helmet` installed and thus the installation failed. I've added the necessary peerDep to the package and to the installation in the README :)

I've also removed the `--dev` as we normally recommend all plugins to be installed in the `dependencies`