### PR TITLE
Switch to react-helmet-async

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@
 
 ## Install
 
-`npm install gatsby-omni-font-loader react-helmet`
+`npm install gatsby-omni-font-loader react-helmet-async`
 
 or
 
-`yarn add gatsby-omni-font-loader react-helmet`
+`yarn add gatsby-omni-font-loader react-helmet-async`
 
 ## Configuration
 
-Add the following snippet to `gatsby-config.js` plugins array.
+Add the following snippet to the `gatsby-config.js` plugins array.
 
 ```js
 {

--- a/components/AsyncFonts.tsx
+++ b/components/AsyncFonts.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Helmet } from "react-helmet"
+import { Helmet } from "react-helmet-async"
 
 export const AsyncFonts: React.FC<{ hrefs: string[] }> = ({ hrefs }) => {
   const links = []

--- a/components/FontListener.tsx
+++ b/components/FontListener.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
-import { Helmet } from "react-helmet"
+import { Helmet } from "react-helmet-async"
 import { kebabCase } from "../utils"
 
 declare var document: { fonts: any }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   },
   "peerDependencies": {
     "gatsby": ">=1",
-    "react-helmet": ">=6.0.0"
+    "react-helmet-async": ">=1.0.0"
   }
 }


### PR DESCRIPTION
This is a proposition more than anything, this is very optionnal.

I feel like switching to `react-helmet-async` would be beneficial and follows the usage trend.
[Helmet Trend](https://www.npmtrends.com/react-head-vs-react-helmet-vs-react-helmet-async)

Personally, I use `react-helmet-async`, and using this plugin meant having both versions of Helmet as dependencies.