### PR TITLE
Added v4.0.0-next to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/codeAdrian/gatsby-omni-font-loader"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0-next",
     "react-helmet": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Hi @codeAdrian,

Thanks for great plugin.
Currently not possible to install on v4, this PR added gatsby v4 to peerDependency.

Thanks!