### PR TITLE
chore: Update peerDeps to v4 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/codeAdrian/gatsby-omni-font-loader"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0-next",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "react-helmet": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Hello 👋 

We've launched Gatsby 4 GA yesterday, so we can change the peerDep.
Happily using it already on https://www.lekoarts.de/ - thanks for your work! :)