### PR TITLE
Fix block render in async mode

### DIFF
--- a/components/AsyncFonts.tsx
+++ b/components/AsyncFonts.tsx
@@ -14,7 +14,8 @@ export const AsyncFonts: React.FC<{ hrefs: string[] }> = ({ hrefs }) => {
       <link
         key={`stylesheet-${href}`}
         rel="stylesheet"
-        media="all"
+        media="print"
+        onLoad={`this.onload=null;this.removeAttribute('media');`}
         href={href}
       />
     )

--- a/generators/getFontConfig.tsx
+++ b/generators/getFontConfig.tsx
@@ -24,7 +24,7 @@ export const getFontConfig = (
   if (arrayCheck(preloadConfig)) {
     preloadConfig.forEach(href => {
       headComponents.push(
-        <link key={`preload-${href}`} rel="stylesheet" href={href} />
+        <link key={`preload-${href}`} rel="preload" as="style" href={href} />
       )
     })
   }


### PR DESCRIPTION
PageSpeed Insights addressed an opportunity of my site:

>Eliminate render-blocking resources 1.88s
>/css2?family=Lobster&display=swap (fonts.googleapis.com) 1.3 KiB 780 ms
>/css2?family=Passion+One:wght@900&display=swap (fonts.googleapis.com) 1.1 KiB 150 ms
> ...

Google font related `<link>` are:
```html
<!-- Group 1 -->
<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="true">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="true">

<!-- Group 2 -->
<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lobster&display=swap">
<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Passion+One:wght@900&display=swap">

<!-- Group 3 -->
<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Lobster&display=swap" data-react-helmet="true">
<link rel="stylesheet" media="all" href="https://fonts.googleapis.com/css2?family=Passion+One:wght@900&display=swap" data-react-helmet="true">

<!-- Group 4 -->
<noscript data-react-helmet="true"><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lobster&display=swap"></noscript>
<noscript data-react-helmet="true"><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Passion+One:wght@900&display=swap"></noscript>
```

This pull request would fix this issue, as I tested.


